### PR TITLE
Tidying up (No functional changes)

### DIFF
--- a/ficsit-companion/include/fractional_number.hpp
+++ b/ficsit-companion/include/fractional_number.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <optional>
 
 class FractionalNumber
 {
@@ -31,8 +32,8 @@ private:
     long long int numerator;
     long long int denominator;
     double value;
-    std::string str_fraction;
-    std::string str_float;
+    std::optional<std::string> str_fraction;
+    std::optional<std::string> str_float;
 };
 
 FractionalNumber operator*(FractionalNumber lhs, const FractionalNumber& rhs);

--- a/ficsit-companion/src/app.cpp
+++ b/ficsit-companion/src/app.cpp
@@ -125,14 +125,14 @@ void App::CreateLink(Pin* start, Pin* end)
     end->link = links.back().get();
     if (start->node->GetKind() != Node::Kind::Craft)
     {
-        if (OrganizerNode* organizer_node = dynamic_cast<OrganizerNode*>(start->node); organizer_node->item == nullptr)
+        if (OrganizerNode* organizer_node = static_cast<OrganizerNode*>(start->node); organizer_node->item == nullptr)
         {
             organizer_node->ChangeItem(end->item);
         }
     }
     if (end->node->GetKind() != Node::Kind::Craft)
     {
-        if (OrganizerNode* organizer_node = dynamic_cast<OrganizerNode*>(end->node); organizer_node->item == nullptr)
+        if (OrganizerNode* organizer_node = static_cast<OrganizerNode*>(end->node); organizer_node->item == nullptr)
         {
             organizer_node->ChangeItem(start->item);
         }
@@ -152,7 +152,7 @@ void App::DeleteLink(const ax::NodeEditor::LinkId id)
             // If either end was an organizer node, check the name is still valid
             if (start->node->GetKind() != Node::Kind::Craft)
             {
-                dynamic_cast<OrganizerNode*>(start->node)->RemoveItemIfNotForced();
+                static_cast<OrganizerNode*>(start->node)->RemoveItemIfNotForced();
             }
         }
         if (Pin* end = (*it)->end; end != nullptr)
@@ -161,7 +161,7 @@ void App::DeleteLink(const ax::NodeEditor::LinkId id)
             // If either end was an organizer node, check the name is still valid
             if (end->node->GetKind() != Node::Kind::Craft)
             {
-                dynamic_cast<OrganizerNode*>(end->node)->RemoveItemIfNotForced();
+                static_cast<OrganizerNode*>(end->node)->RemoveItemIfNotForced();
             }
         }
         links.erase(it);
@@ -219,7 +219,7 @@ void App::UpdateNodesRate()
         {
         case Node::Kind::Craft:
         {
-            CraftNode* node = dynamic_cast<CraftNode*>(updating_pin->node);
+            CraftNode* node = static_cast<CraftNode*>(updating_pin->node);
             node->current_rate = updating_pin->current_rate / updating_pin->base_rate;
             for (auto& p : node->ins)
             {
@@ -413,7 +413,7 @@ void App::UpdateNodesRate()
             continue;
         }
 
-        CraftNode* node = dynamic_cast<CraftNode*>(n.get());
+        CraftNode* node = static_cast<CraftNode*>(n.get());
 
         for (auto& p : n->ins)
         {
@@ -445,7 +445,7 @@ void App::ExportToFile(const std::string& filename) const
         };
         if (n->GetKind() == Node::Kind::Craft)
         {
-            const CraftNode* craft_n = dynamic_cast<const CraftNode*>(n.get());
+            const CraftNode* craft_n = static_cast<const CraftNode*>(n.get());
             node["rate"] = {
                 { "num", craft_n->current_rate.GetNumerator()},
                 { "den", craft_n->current_rate.GetDenominator()}
@@ -454,7 +454,7 @@ void App::ExportToFile(const std::string& filename) const
         }
         else
         {
-            const OrganizerNode* org_n = dynamic_cast<const OrganizerNode*>(n.get());
+            const OrganizerNode* org_n = static_cast<const OrganizerNode*>(n.get());
             node["item"] = org_n->item == nullptr ? "" : org_n->item->name;
             node["ins"] = Json::Array();
             for (auto& i : n->ins)
@@ -613,7 +613,7 @@ void App::LoadFromFile(const std::string& filename)
             nodes.emplace_back(std::make_unique<CraftNode>(GetNextId(), recipe, std::bind(&App::GetNextId, this)));
             ax::NodeEditor::SetNodePosition(nodes.back()->id, ImVec2(n["pos"]["x"].get<float>(), n["pos"]["y"].get<float>()));
 
-            CraftNode* craft_node = dynamic_cast<CraftNode*>(nodes.back().get());
+            CraftNode* craft_node = static_cast<CraftNode*>(nodes.back().get());
 
             craft_node->current_rate = FractionalNumber(n["rate"]["num"].get<long long int>(), n["rate"]["den"].get<long long int>());
             for (auto& p : craft_node->ins)
@@ -646,7 +646,7 @@ void App::LoadFromFile(const std::string& filename)
                 break;
             }
 
-            OrganizerNode* org_node = dynamic_cast<OrganizerNode*>(nodes.back().get());
+            OrganizerNode* org_node = static_cast<OrganizerNode*>(nodes.back().get());
             org_node->ChangeItem(item_it->second.get());
 
             for (int i = 0; i < n["ins"].size(); ++i)
@@ -883,7 +883,7 @@ void App::RenderLeftPanel()
 
         if (n->GetKind() == Node::Kind::Craft)
         {
-            const CraftNode* node = dynamic_cast<const CraftNode*>(n.get());
+            const CraftNode* node = static_cast<const CraftNode*>(n.get());
             machines[node->recipe->machine] += node->current_rate;
         }
     }
@@ -942,7 +942,7 @@ void App::RenderNodes()
     const float rate_width = ImGui::CalcTextSize("0000.000").x;
     for (const auto& node : nodes)
     {
-        const bool isnt_balanced = node->GetKind() != Node::Kind::Craft && !dynamic_cast<OrganizerNode*>(node.get())->IsBalanced();
+        const bool isnt_balanced = node->GetKind() != Node::Kind::Craft && !static_cast<OrganizerNode*>(node.get())->IsBalanced();
         if (isnt_balanced)
         {
             ax::NodeEditor::PushStyleColor(ax::NodeEditor::StyleColor_NodeBorder, ImColor(255, 0, 0));
@@ -956,7 +956,7 @@ void App::RenderNodes()
                 switch (node->GetKind())
                 {
                 case Node::Kind::Craft:
-                    ImGui::TextUnformatted(dynamic_cast<CraftNode*>(node.get())->recipe->name.c_str());
+                    ImGui::TextUnformatted(static_cast<CraftNode*>(node.get())->recipe->name.c_str());
                     break;
                 case Node::Kind::Merger:
                     ImGui::TextUnformatted("Merger");
@@ -1126,7 +1126,7 @@ void App::RenderNodes()
                 ImGui::SetNextItemWidth(rate_width);
                 if (node->GetKind() == Node::Kind::Craft)
                 {
-                    CraftNode* craft_node = dynamic_cast<CraftNode*>(node.get());
+                    CraftNode* craft_node = static_cast<CraftNode*>(node.get());
                     ImGui::InputText("##rate", &craft_node->current_rate.GetStringFloat(), ImGuiInputTextFlags_CharsDecimal);
                     if (ImGui::IsItemDeactivatedAfterEdit())
                     {
@@ -1158,7 +1158,7 @@ void App::RenderNodes()
                 }
                 else
                 {
-                    OrganizerNode* org_node = dynamic_cast<OrganizerNode*>(node.get());
+                    OrganizerNode* org_node = static_cast<OrganizerNode*>(node.get());
                     if (org_node->item != nullptr)
                     {
                         ImGui::Spring(0.0f);

--- a/ficsit-companion/src/app.cpp
+++ b/ficsit-companion/src/app.cpp
@@ -125,14 +125,14 @@ void App::CreateLink(Pin* start, Pin* end)
     end->link = links.back().get();
     if (start->node->GetKind() != Node::Kind::Craft)
     {
-        if (OrganizerNode* organizer_node = reinterpret_cast<OrganizerNode*>(start->node); organizer_node->item == nullptr)
+        if (OrganizerNode* organizer_node = dynamic_cast<OrganizerNode*>(start->node); organizer_node->item == nullptr)
         {
             organizer_node->ChangeItem(end->item);
         }
     }
     if (end->node->GetKind() != Node::Kind::Craft)
     {
-        if (OrganizerNode* organizer_node = reinterpret_cast<OrganizerNode*>(end->node); organizer_node->item == nullptr)
+        if (OrganizerNode* organizer_node = dynamic_cast<OrganizerNode*>(end->node); organizer_node->item == nullptr)
         {
             organizer_node->ChangeItem(start->item);
         }
@@ -152,7 +152,7 @@ void App::DeleteLink(const ax::NodeEditor::LinkId id)
             // If either end was an organizer node, check the name is still valid
             if (start->node->GetKind() != Node::Kind::Craft)
             {
-                reinterpret_cast<OrganizerNode*>(start->node)->RemoveItemIfNotForced();
+                dynamic_cast<OrganizerNode*>(start->node)->RemoveItemIfNotForced();
             }
         }
         if (Pin* end = (*it)->end; end != nullptr)
@@ -161,7 +161,7 @@ void App::DeleteLink(const ax::NodeEditor::LinkId id)
             // If either end was an organizer node, check the name is still valid
             if (end->node->GetKind() != Node::Kind::Craft)
             {
-                reinterpret_cast<OrganizerNode*>(end->node)->RemoveItemIfNotForced();
+                dynamic_cast<OrganizerNode*>(end->node)->RemoveItemIfNotForced();
             }
         }
         links.erase(it);
@@ -219,7 +219,7 @@ void App::UpdateNodesRate()
         {
         case Node::Kind::Craft:
         {
-            CraftNode* node = reinterpret_cast<CraftNode*>(updating_pin->node);
+            CraftNode* node = dynamic_cast<CraftNode*>(updating_pin->node);
             node->current_rate = updating_pin->current_rate / updating_pin->base_rate;
             for (auto& p : node->ins)
             {
@@ -445,7 +445,7 @@ void App::ExportToFile(const std::string& filename) const
         };
         if (n->GetKind() == Node::Kind::Craft)
         {
-            const CraftNode* craft_n = reinterpret_cast<const CraftNode*>(n.get());
+            const CraftNode* craft_n = dynamic_cast<const CraftNode*>(n.get());
             node["rate"] = {
                 { "num", craft_n->current_rate.GetNumerator()},
                 { "den", craft_n->current_rate.GetDenominator()}
@@ -454,7 +454,7 @@ void App::ExportToFile(const std::string& filename) const
         }
         else
         {
-            const OrganizerNode* org_n = reinterpret_cast<const OrganizerNode*>(n.get());
+            const OrganizerNode* org_n = dynamic_cast<const OrganizerNode*>(n.get());
             node["item"] = org_n->item == nullptr ? "" : org_n->item->name;
             node["ins"] = Json::Array();
             for (auto& i : n->ins)
@@ -613,7 +613,7 @@ void App::LoadFromFile(const std::string& filename)
             nodes.emplace_back(std::make_unique<CraftNode>(GetNextId(), recipe, std::bind(&App::GetNextId, this)));
             ax::NodeEditor::SetNodePosition(nodes.back()->id, ImVec2(n["pos"]["x"].get<float>(), n["pos"]["y"].get<float>()));
 
-            CraftNode* craft_node = reinterpret_cast<CraftNode*>(nodes.back().get());
+            CraftNode* craft_node = dynamic_cast<CraftNode*>(nodes.back().get());
 
             craft_node->current_rate = FractionalNumber(n["rate"]["num"].get<long long int>(), n["rate"]["den"].get<long long int>());
             for (auto& p : craft_node->ins)
@@ -646,7 +646,7 @@ void App::LoadFromFile(const std::string& filename)
                 break;
             }
 
-            OrganizerNode* org_node = reinterpret_cast<OrganizerNode*>(nodes.back().get());
+            OrganizerNode* org_node = dynamic_cast<OrganizerNode*>(nodes.back().get());
             org_node->ChangeItem(item_it->second.get());
 
             for (int i = 0; i < n["ins"].size(); ++i)
@@ -883,7 +883,7 @@ void App::RenderLeftPanel()
 
         if (n->GetKind() == Node::Kind::Craft)
         {
-            const CraftNode* node = reinterpret_cast<const CraftNode*>(n.get());
+            const CraftNode* node = dynamic_cast<const CraftNode*>(n.get());
             machines[node->recipe->machine] += node->current_rate;
         }
     }
@@ -942,7 +942,7 @@ void App::RenderNodes()
     const float rate_width = ImGui::CalcTextSize("0000.000").x;
     for (const auto& node : nodes)
     {
-        const bool isnt_balanced = node->GetKind() != Node::Kind::Craft && !reinterpret_cast<OrganizerNode*>(node.get())->IsBalanced();
+        const bool isnt_balanced = node->GetKind() != Node::Kind::Craft && !dynamic_cast<OrganizerNode*>(node.get())->IsBalanced();
         if (isnt_balanced)
         {
             ax::NodeEditor::PushStyleColor(ax::NodeEditor::StyleColor_NodeBorder, ImColor(255, 0, 0));
@@ -956,7 +956,7 @@ void App::RenderNodes()
                 switch (node->GetKind())
                 {
                 case Node::Kind::Craft:
-                    ImGui::TextUnformatted(reinterpret_cast<CraftNode*>(node.get())->recipe->name.c_str());
+                    ImGui::TextUnformatted(dynamic_cast<CraftNode*>(node.get())->recipe->name.c_str());
                     break;
                 case Node::Kind::Merger:
                     ImGui::TextUnformatted("Merger");
@@ -1126,7 +1126,7 @@ void App::RenderNodes()
                 ImGui::SetNextItemWidth(rate_width);
                 if (node->GetKind() == Node::Kind::Craft)
                 {
-                    CraftNode* craft_node = reinterpret_cast<CraftNode*>(node.get());
+                    CraftNode* craft_node = dynamic_cast<CraftNode*>(node.get());
                     ImGui::InputText("##rate", &craft_node->current_rate.GetStringFloat(), ImGuiInputTextFlags_CharsDecimal);
                     if (ImGui::IsItemDeactivatedAfterEdit())
                     {
@@ -1158,7 +1158,7 @@ void App::RenderNodes()
                 }
                 else
                 {
-                    OrganizerNode* org_node = reinterpret_cast<OrganizerNode*>(node.get());
+                    OrganizerNode* org_node = dynamic_cast<OrganizerNode*>(node.get());
                     if (org_node->item != nullptr)
                     {
                         ImGui::Spring(0.0f);

--- a/ficsit-companion/src/fractional_number.cpp
+++ b/ficsit-companion/src/fractional_number.cpp
@@ -79,7 +79,7 @@ double FractionalNumber::GetValue() const
 
 std::string& FractionalNumber::GetStringFraction()
 {
-    if (str_fraction.empty())
+    if (!str_fraction.has_value())
     {
         if (denominator == 1)
         {
@@ -90,18 +90,19 @@ std::string& FractionalNumber::GetStringFraction()
             str_fraction = std::to_string(numerator) + "/" + std::to_string(denominator);
         }
     }
-    return str_fraction;
+
+    return str_fraction.value();
 }
 
 std::string& FractionalNumber::GetStringFloat()
 {
-    if (str_float.empty())
+    if (!str_float.has_value())
     {
         std::stringstream sstream;
         sstream << std::fixed << std::setprecision(3) << value;
         str_float = sstream.str();
     }
-    return str_float;
+    return str_float.value();
 }
 
 FractionalNumber& FractionalNumber::operator*=(const FractionalNumber& rhs)
@@ -159,8 +160,8 @@ void FractionalNumber::Simplify()
 void FractionalNumber::UpdateValue()
 {
     value = static_cast<double>(numerator) / denominator;
-    str_float = "";
-    str_fraction = "";
+    str_float.reset();
+    str_fraction.reset();
 }
 
 FractionalNumber operator*(FractionalNumber lhs, const FractionalNumber& rhs)

--- a/ficsit-companion/src/pin.cpp
+++ b/ficsit-companion/src/pin.cpp
@@ -8,7 +8,7 @@ Pin::Pin(const ax::NodeEditor::PinId id, const ax::NodeEditor::PinKind direction
 {
     if (node->GetKind() == Node::Kind::Craft)
     {
-        current_rate = reinterpret_cast<CraftNode*>(node)->current_rate * base_rate;
+        current_rate = dynamic_cast<CraftNode*>(node)->current_rate * base_rate;
     }
 }
 

--- a/ficsit-companion/src/pin.cpp
+++ b/ficsit-companion/src/pin.cpp
@@ -8,7 +8,7 @@ Pin::Pin(const ax::NodeEditor::PinId id, const ax::NodeEditor::PinKind direction
 {
     if (node->GetKind() == Node::Kind::Craft)
     {
-        current_rate = dynamic_cast<CraftNode*>(node)->current_rate * base_rate;
+        current_rate = static_cast<CraftNode*>(node)->current_rate * base_rate;
     }
 }
 


### PR DESCRIPTION
A couple of things I noticed while browsing the code (and before realizing the changes I wanted to propose were actually already implemented :^) )

- Convert some `reinterpret_cast` into more appropriate `dynamic_cast`s for downcasting in a virtual hierarchy.
- Avoid any string allocation in FractionalNumber until they're actually used. 
  I noticed this type is used for arithmetic operations in the rate update and doing a bunch of unnecessary allocation there, at least in debug mode.

Sorry for the boring PR and thanks for making and publishing this tool, I'll definitely use it when 1.0 finally comes out!
 