### PR TITLE
Added count of Machines Pr. Item

### DIFF
--- a/ficsit-companion/src/app.cpp
+++ b/ficsit-companion/src/app.cpp
@@ -1015,6 +1015,7 @@ void App::RenderLeftPanel()
     std::map<const Item*, FractionalNumber> inputs;
     std::map<const Item*, FractionalNumber> outputs;
     std::map<std::string, FractionalNumber> machines;
+    std::map<std::pair<std::string, const Item*>, FractionalNumber> machinesPrItem;
 
     // Gather all inputs/outputs/machines
     for (const auto& n : nodes)
@@ -1038,6 +1039,10 @@ void App::RenderLeftPanel()
         {
             const CraftNode* node = static_cast<const CraftNode*>(n.get());
             machines[node->recipe->machine] += node->current_rate;
+            for (const auto& p : node->outs) 
+            {
+                machinesPrItem[{node->recipe->machine, p->item}] += node->current_rate;
+            }
         }
     }
 
@@ -1087,6 +1092,24 @@ void App::RenderLeftPanel()
         ImGui::EndDisabled();
         ImGui::SameLine();
         ImGui::TextUnformatted(machine.c_str());
+    }
+    ImGui::SeparatorText("Machines pr Item");
+    for (auto& [key, n] : machinesPrItem)
+    {
+        ImGui::SetNextItemWidth(rate_width);
+        ImGui::BeginDisabled();
+        ImGui::InputText("##rate", &n.GetStringFloat(), ImGuiInputTextFlags_ReadOnly);
+        if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
+        {
+            ImGui::SetTooltip("%s", n.GetStringFraction().c_str());
+        }
+        ImGui::EndDisabled();
+        ImGui::SameLine();
+        ImGui::TextUnformatted(key.first.c_str());
+        ImGui::SameLine();
+        ImGui::Image((void*)(intptr_t)key.second->icon_gl_index, ImVec2(ImGui::GetTextLineHeightWithSpacing(), ImGui::GetTextLineHeightWithSpacing()));
+        ImGui::SameLine();
+        ImGui::TextUnformatted(key.second->name.c_str());
     }
 }
 

--- a/ficsit-companion/src/app.cpp
+++ b/ficsit-companion/src/app.cpp
@@ -1015,7 +1015,7 @@ void App::RenderLeftPanel()
     std::map<const Item*, FractionalNumber> inputs;
     std::map<const Item*, FractionalNumber> outputs;
     std::map<std::string, FractionalNumber> machines;
-    std::map<std::pair<std::string, const Item*>, FractionalNumber> machinesPrItem;
+    std::map<std::pair<std::string, const Item*>, FractionalNumber> machines_pr_item;
 
     // Gather all inputs/outputs/machines
     for (const auto& n : nodes)
@@ -1041,7 +1041,7 @@ void App::RenderLeftPanel()
             machines[node->recipe->machine] += node->current_rate;
             for (const auto& p : node->outs) 
             {
-                machinesPrItem[{node->recipe->machine, p->item}] += node->current_rate;
+                machines_pr_item[{node->recipe->machine, p->item}] += node->current_rate;
             }
         }
     }
@@ -1053,11 +1053,11 @@ void App::RenderLeftPanel()
         ImGui::SetNextItemWidth(rate_width);
         ImGui::BeginDisabled();
         ImGui::InputText("##rate", &n.GetStringFloat(), ImGuiInputTextFlags_ReadOnly);
+        ImGui::EndDisabled();
         if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
         {
             ImGui::SetTooltip("%s", n.GetStringFraction().c_str());
         }
-        ImGui::EndDisabled();
         ImGui::SameLine();
         ImGui::Image((void*)(intptr_t)item->icon_gl_index, ImVec2(ImGui::GetTextLineHeightWithSpacing(), ImGui::GetTextLineHeightWithSpacing()));
         ImGui::SameLine();
@@ -1069,11 +1069,11 @@ void App::RenderLeftPanel()
         ImGui::SetNextItemWidth(rate_width);
         ImGui::BeginDisabled();
         ImGui::InputText("##rate", &n.GetStringFloat(), ImGuiInputTextFlags_ReadOnly);
+        ImGui::EndDisabled();
         if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
         {
             ImGui::SetTooltip("%s", n.GetStringFraction().c_str());
         }
-        ImGui::EndDisabled();
         ImGui::SameLine();
         ImGui::Image((void*)(intptr_t)item->icon_gl_index, ImVec2(ImGui::GetTextLineHeightWithSpacing(), ImGui::GetTextLineHeightWithSpacing()));
         ImGui::SameLine();
@@ -1085,25 +1085,25 @@ void App::RenderLeftPanel()
         ImGui::SetNextItemWidth(rate_width);
         ImGui::BeginDisabled();
         ImGui::InputText("##rate", &n.GetStringFloat(), ImGuiInputTextFlags_ReadOnly);
+        ImGui::EndDisabled();
         if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
         {
             ImGui::SetTooltip("%s", n.GetStringFraction().c_str());
         }
-        ImGui::EndDisabled();
         ImGui::SameLine();
         ImGui::TextUnformatted(machine.c_str());
     }
     ImGui::SeparatorText("Machines pr Item");
-    for (auto& [key, n] : machinesPrItem)
+    for (auto& [key, n] : machines_pr_item)
     {
         ImGui::SetNextItemWidth(rate_width);
         ImGui::BeginDisabled();
         ImGui::InputText("##rate", &n.GetStringFloat(), ImGuiInputTextFlags_ReadOnly);
+        ImGui::EndDisabled();
         if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
         {
             ImGui::SetTooltip("%s", n.GetStringFraction().c_str());
         }
-        ImGui::EndDisabled();
         ImGui::SameLine();
         ImGui::TextUnformatted(key.first.c_str());
         ImGui::SameLine();

--- a/ficsit-companion/src/app.cpp
+++ b/ficsit-companion/src/app.cpp
@@ -1015,7 +1015,7 @@ void App::RenderLeftPanel()
     std::map<const Item*, FractionalNumber> inputs;
     std::map<const Item*, FractionalNumber> outputs;
     std::map<std::string, FractionalNumber> machines;
-    std::map<std::pair<std::string, const Item*>, FractionalNumber> machines_pr_item;
+    std::map<std::pair<std::string, const Recipe*>, FractionalNumber> machines_pr_item;
 
     // Gather all inputs/outputs/machines
     for (const auto& n : nodes)
@@ -1039,10 +1039,7 @@ void App::RenderLeftPanel()
         {
             const CraftNode* node = static_cast<const CraftNode*>(n.get());
             machines[node->recipe->machine] += node->current_rate;
-            for (const auto& p : node->outs) 
-            {
-                machines_pr_item[{node->recipe->machine, p->item}] += node->current_rate;
-            }
+			machines_pr_item[{node->recipe->machine, node->recipe}] += node->current_rate;
         }
     }
 
@@ -1106,10 +1103,21 @@ void App::RenderLeftPanel()
         }
         ImGui::SameLine();
         ImGui::TextUnformatted(key.first.c_str());
-        ImGui::SameLine();
-        ImGui::Image((void*)(intptr_t)key.second->icon_gl_index, ImVec2(ImGui::GetTextLineHeightWithSpacing(), ImGui::GetTextLineHeightWithSpacing()));
-        ImGui::SameLine();
-        ImGui::TextUnformatted(key.second->name.c_str());
+        bool first_item = true;
+        for (auto& item : key.second->outs)
+        {
+            if (!first_item) {
+                //ImGui::SameLine();
+				ImGui::TextUnformatted("        ");
+                ImGui::SameLine();
+				ImGui::TextUnformatted(std::string(key.first.length(), ' ').c_str());
+            }
+            ImGui::SameLine();
+			ImGui::Image((void*)(intptr_t)item.item->icon_gl_index, ImVec2(ImGui::GetTextLineHeightWithSpacing(), ImGui::GetTextLineHeightWithSpacing()));
+			ImGui::SameLine();
+			ImGui::TextUnformatted(item.item->name.c_str());
+            first_item = false;
+        }
     }
 }
 


### PR DESCRIPTION
I like to build my factories with 1 area for Iron Rod Constructors, 1 area for Iron Plate Constructors and so forth with a bus connecting them.
Though when planning a factory in a planner like this it can be easier to have each Iron Rod consumer have its own Iron Rod Constructor.
So this overview gives me the best of both worlds: The ability to have a clear Plan, and the ability to know how many machines I need in each area.