### PR TITLE
Navigate with keyboard

### DIFF
--- a/ficsit-companion/src/app.cpp
+++ b/ficsit-companion/src/app.cpp
@@ -713,7 +713,7 @@ void App::Render()
     ax::NodeEditor::PushStyleColor(ax::NodeEditor::StyleColor_Flow, ImColor(1.0f, 1.0f, 0.0f));
     ax::NodeEditor::PushStyleColor(ax::NodeEditor::StyleColor_FlowMarker, ImColor(1.0f, 1.0f, 0.0f));
 
-    ImGui::BeginChild("#left_panel", ImVec2(0.2f * ImGui::GetWindowSize().x, 0.0f), false, ImGuiWindowFlags_HorizontalScrollbar);
+    ImGui::BeginChild("#left_panel", ImVec2(0.2f * ImGui::GetWindowSize().x, 0.0f), false, ImGuiWindowFlags_HorizontalScrollbar | ImGuiWindowFlags_NoNavInputs);
     RenderLeftPanel();
     ImGui::EndChild();
 

--- a/ficsit-companion/src/main.cpp
+++ b/ficsit-companion/src/main.cpp
@@ -113,7 +113,7 @@ bool Render(SDL_Window* window, App* app)
 
     ImGui::SetNextWindowPos(ImVec2(0, 0));
     ImGui::SetNextWindowSize(ImGui::GetIO().DisplaySize);
-    
+
     ImGui::Begin("Ficsit Companion", NULL,
         ImGuiWindowFlags_NoNavInputs |
         ImGuiWindowFlags_NoResize |

--- a/ficsit-companion/src/main.cpp
+++ b/ficsit-companion/src/main.cpp
@@ -113,8 +113,9 @@ bool Render(SDL_Window* window, App* app)
 
     ImGui::SetNextWindowPos(ImVec2(0, 0));
     ImGui::SetNextWindowSize(ImGui::GetIO().DisplaySize);
-
+    
     ImGui::Begin("Ficsit Companion", NULL,
+        ImGuiWindowFlags_NoNavInputs |
         ImGuiWindowFlags_NoResize |
         ImGuiWindowFlags_NoMove |
         ImGuiWindowFlags_NoCollapse |
@@ -238,7 +239,8 @@ int main(int argc, char* argv[])
     IMGUI_CHECKVERSION();
     ImGui::CreateContext();
     ImGui::GetIO().IniFilename = nullptr; // Don't save window layout in ini file
-
+    ImGui::GetIO().ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;//Enable Keyboard Navigation
+    
     // Style
     ImGui::StyleColorsDark();
 


### PR DESCRIPTION
Makes the contextmenu navigatable with keyboard, to faster select recipees